### PR TITLE
docs: add example test using app fixture in FastAPI guide

### DIFF
--- a/src/content/guides/05-fastapi-test-settings.md
+++ b/src/content/guides/05-fastapi-test-settings.md
@@ -96,3 +96,18 @@ I have a repo for the full example: [https://github.com/getmarkus/fastapi-test-s
        """Create test app instance only during test execution."""
        return create_app()
    ```
+
+6. Create a test that uses the app fixture
+
+   ```python
+   from fastapi.testclient import TestClient
+
+   from .conftest import settings
+
+
+   def test_read_main(client: TestClient):
+       response = client.get("/")
+       assert response.status_code == 200
+       assert response.json() == {"msg": "Test App"}
+       assert response.json() == {"msg": settings.app_name}
+   ```


### PR DESCRIPTION
Add a new section to the FastAPI testing guide that demonstrates 
how to create a test using the app fixture. This enhances the 
documentation by providing a practical example for users, 
showcasing how to verify the main endpoint's response and 
ensure it matches the expected app name from settings.